### PR TITLE
make openid discovery fallible and retry during requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
+
+[[package]]
 name = "async-trait"
 version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3177,7 @@ name = "shine-identity"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "async-trait",
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ harsh = "0.2"
 
 futures = "0.3"
 async-trait = "0.1"
+async-once-cell = "0.5"
 tokio = {version = "1.27", features = ["macros", "rt-multi-thread", "signal"] }
 
 bb8 = "0.8"

--- a/integration-test/regression/health.feature
+++ b/integration-test/regression/health.feature
@@ -1,9 +1,15 @@
 Feature: fetching User Details
 
-  Background:
-    * url karate.properties['utils'].serviceUrl
- 
   Scenario: testing the get call for User Details
+    Given url karate.properties['utils'].serviceUrl
     * path '/info/ready'
-    When method GET
+    * method GET
     Then status 200
+
+  Scenario: testing the get call for User Details
+    Given url karate.properties['utils'].identityUrl
+    * path '/api/auth/providers'
+    * method GET
+    Then status 200
+    * def expectedProviders = ["oauth2_flow", "openid_flow"]
+    * match response == { "providers": #(^^expectedProviders) }

--- a/integration-test/test.js
+++ b/integration-test/test.js
@@ -8,38 +8,12 @@ const dockerOptions = {
     log: true
 };
 
-const mocks = ['mocking/openid.feature'];
-
 async function setup() {
-    // start up mock server required for service initialization
-    await new Promise((resolve, _reject) => {
-        console.log('Starting mock server...');
-        const args = '-p 8090 -m ' + mocks.join(',');
-
-        // some ugly hack to start karate in the background using jbang
-        process.env['KARATE_META'] = 'npm:' + process.env.npm_package_version;
-        const argLine =
-            karate.jvm.args + ' ' + karate.executable() + ' ' + args;
-        const sh = shell.exec('jbang ' + argLine, { async: true });
-        sh.stdout.on('data', (data) => {
-            if (data.includes('server started')) {
-                resolve('');
-            }
-        });
-    });
-
     console.log('Starting service...');
     await dockerCompose.upAll({
         commandOptions: ['--build'],
         ...dockerOptions
     });
-
-    console.log('Stopping mock server...');
-    try {
-        await fetch('http://localhost:8090/stop');
-    } catch {
-        /* it should be an ECONNRESET as karate has been stopped */
-    }
     console.log('Setup completed.');
 }
 

--- a/src/auth/auth_service.rs
+++ b/src/auth/auth_service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{self, AuthSessionMeta, OAuth2Client, OIDCClient, TokenGenerator},
+    auth::{self, AuthSessionMeta, OAuth2Client, OIDCClient, OIDCDiscoveryError, TokenGenerator},
     db::{IdentityManager, NameGenerator, SessionManager},
 };
 use axum::{Extension, Router};
@@ -77,8 +77,7 @@ pub struct AuthConfig {
     #[serde(flatten)]
     pub auth_session: AuthSessionConfig,
 
-    /// If enabled, when openid discovery fails, continue, but skip the provider. It is mainly used for testing where
-    /// mocking of openid is not complete.
+    /// If enabled, the openid discovery errors are ignored during startup and won't prohibit service startup.
     openid_ignore_discovery_error: Option<bool>,
     /// List of external providers using the OpenId Connect protocol
     pub openid: HashMap<String, OIDCConfig>,
@@ -105,7 +104,7 @@ pub enum AuthBuildError {
     #[error("Invalid redirect url: {0}")]
     RedirectUrl(String),
     #[error("Failed to discover open id: {0}")]
-    Discovery(String),
+    OIDCDiscovery(OIDCDiscoveryError),
 }
 
 struct Inner {

--- a/src/auth/auth_service_utils.rs
+++ b/src/auth/auth_service_utils.rs
@@ -16,6 +16,8 @@ use thiserror::Error as ThisError;
 use url::Url;
 use uuid::Uuid;
 
+use super::oidc::OIDCDiscoveryError;
+
 #[derive(Debug, ThisError)]
 pub(in crate::auth) enum UserCreateError {
     #[error("Retry limit reach for user creation")]
@@ -150,6 +152,9 @@ pub(in crate::auth) enum AuthError {
     #[error("Internal server error: {0}")]
     InternalServerError(String),
 
+    #[error("OpenId discovery failed")]
+    OIDCDiscovery(OIDCDiscoveryError),
+
     #[error("External provider has already been linked to another user already")]
     ProviderAlreadyUsed,
     #[error("Email has already been linked to another user already")]
@@ -192,6 +197,7 @@ impl AuthServiceState {
             AuthError::TokenExpired => ("sessionExpired", StatusCode::UNAUTHORIZED, String::new()),
             AuthError::SessionExpired => ("sessionExpired", StatusCode::UNAUTHORIZED, String::new()),
             AuthError::InternalServerError(_) => ("internalError", StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            AuthError::OIDCDiscovery(err) => ("authError", StatusCode::INTERNAL_SERVER_ERROR, err.0),
             AuthError::ProviderAlreadyUsed => ("providerAlreadyUsed", StatusCode::CONFLICT, String::new()),
             AuthError::EmailAlreadyUsed => ("emailAlreadyUsed", StatusCode::CONFLICT, String::new()),
             AuthError::MissingPrecondition => ("preconditionFailed", StatusCode::PRECONDITION_FAILED, String::new()),

--- a/src/auth/auth_service_utils.rs
+++ b/src/auth/auth_service_utils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{auth_session::TokenLogin, AuthServiceState, AuthSession, TokenGeneratorError},
+    auth::{auth_session::TokenLogin, AuthServiceState, AuthSession, OIDCDiscoveryError, TokenGeneratorError},
     db::{ExternalUserInfo, Identity, IdentityError, NameGeneratorError, TokenKind},
 };
 use axum::{
@@ -15,8 +15,6 @@ use std::fmt;
 use thiserror::Error as ThisError;
 use url::Url;
 use uuid::Uuid;
-
-use super::oidc::OIDCDiscoveryError;
 
 #[derive(Debug, ThisError)]
 pub(in crate::auth) enum UserCreateError {

--- a/src/auth/oidc/page_oidc_link.rs
+++ b/src/auth/oidc/page_oidc_link.rs
@@ -34,9 +34,13 @@ async fn oidc_link(
         return state.page_error(auth_session, AuthError::LoginRequired, query.error_url.as_ref());
     }
 
+    let core_client = match client.client().await {
+        Ok(client) => client,
+        Err(err) => return state.page_error(auth_session, AuthError::OIDCDiscovery(err), query.error_url.as_ref()),
+    };
+
     let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
-    let (authorize_url, csrf_state, nonce) = client
-        .client
+    let (authorize_url, csrf_state, nonce) = core_client
         .authorize_url(
             CoreAuthenticationFlow::AuthorizationCode,
             CsrfToken::new_random,

--- a/src/auth/oidc/page_oidc_login.rs
+++ b/src/auth/oidc/page_oidc_login.rs
@@ -35,9 +35,13 @@ async fn oidc_login(
         return state.page_error(auth_session, AuthError::LogoutRequired, query.error_url.as_ref());
     }
 
+    let core_client = match client.client().await {
+        Ok(client) => client,
+        Err(err) => return state.page_error(auth_session, AuthError::OIDCDiscovery(err), query.error_url.as_ref()),
+    };
+
     let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
-    let (authorize_url, csrf_state, nonce) = client
-        .client
+    let (authorize_url, csrf_state, nonce) = core_client
         .authorize_url(
             CoreAuthenticationFlow::AuthorizationCode,
             CsrfToken::new_random,


### PR DESCRIPTION
resolve #7 
- use async-once-cell for openid client and discovery
- registered providers depends only on the configuration (includes test). Ignore_discovery config option controls weather the startup should be aborted or not or error, but provider is registered anyway.
